### PR TITLE
Add initial GUT test suite for Gedis (strings, hashes, lists, sets, TTL)

### DIFF
--- a/.github/.gitkeep
+++ b/.github/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,8 @@
+; Minimal project for running tests with Godot 4.x
+config_version=5
+
+[application]
+config/name="Gedis"
+
+[rendering]
+renderer/rendering_method="mobile"

--- a/test/unit/test_gedis_expiry.gd
+++ b/test/unit/test_gedis_expiry.gd
@@ -1,0 +1,25 @@
+extends GutTest
+
+const GEDIS := preload("res://addons/gedis/gedis.gd")
+
+func before_each():
+	self.g = GEDIS.new()
+
+func test_expire_ttl_and_eviction():
+	g.set("k", "v")
+	assert_true(g.expire("k", 1))
+	var t := g.ttl("k")
+	assert_true(t == 0 || t == 1, "ttl should be 0 or 1 just after setting 1s expiry")
+	OS.delay_msec(1200) # wait for expiry
+	assert_false(g.exists("k"))
+	assert_eq(g.get("k", "missing"), "missing")
+
+func test_persist_and_flushall():
+	g.set("a", 1)
+	g.set("b", 2)
+	g.expire("a", 10)
+	assert_true(g.persist("a"))
+	assert_eq(g.ttl("a"), -1)
+	g.flushall()
+	assert_false(g.exists("a"))
+	assert_false(g.exists("b"))

--- a/test/unit/test_gedis_hashes.gd
+++ b/test/unit/test_gedis_hashes.gd
@@ -1,0 +1,21 @@
+extends GutTest
+
+const GEDIS := preload("res://addons/gedis/gedis.gd")
+
+func before_each():
+	self.g = GEDIS.new()
+
+func test_hset_hget_and_default():
+	g.hset("h", "a", 10)
+	g.hset("h", "b", 20)
+	assert_eq(g.hget("h", "a"), 10)
+	assert_eq(g.hget("h", "missing", 99), 99)
+
+func test_hdel_and_hgetall():
+	g.hset("h", "a", 10)
+	g.hset("h", "b", 20)
+	assert_eq(g.hdel("h", "a"), 1)
+	assert_eq(g.hdel("h", "a"), 0)
+	var all := g.hgetall("h")
+	assert_eq(all.size(), 1)
+	assert_true(all.has("b"))

--- a/test/unit/test_gedis_lists.gd
+++ b/test/unit/test_gedis_lists.gd
@@ -1,0 +1,19 @@
+extends GutTest
+
+const GEDIS := preload("res://addons/gedis/gedis.gd")
+
+func before_each():
+	self.g = GEDIS.new()
+
+func test_lpush_rpush_and_len():
+	assert_eq(g.rpush("l", "x"), 1)
+	assert_eq(g.lpush("l", "y"), 2)
+	assert_eq(g.llen("l"), 2)
+
+func test_lpop_rpop_and_empty():
+	g.rpush("l", 1)
+	g.rpush("l", 2)
+	assert_eq(g.lpop("l"), 1)
+	assert_eq(g.rpop("l"), 2)
+	assert_eq(g.lpop("l"), null)
+	assert_eq(g.rpop("l"), null)

--- a/test/unit/test_gedis_sets.gd
+++ b/test/unit/test_gedis_sets.gd
@@ -1,0 +1,16 @@
+extends GutTest
+
+const GEDIS := preload("res://addons/gedis/gedis.gd")
+
+func before_each():
+	self.g = GEDIS.new()
+
+func test_sadd_srem_smembers_sismember():
+	assert_eq(g.sadd("s", "a"), 1)
+	assert_eq(g.sadd("s", "a"), 0, "second add is no-op")
+	assert_true(g.sismember("s", "a"))
+	var members := g.smembers("s")
+	assert_true(members.has("a"))
+	assert_eq(g.srem("s", "a"), 1)
+	assert_false(g.sismember("s", "a"))
+	assert_eq(g.srem("s", "a"), 0)

--- a/test/unit/test_gedis_strings.gd
+++ b/test/unit/test_gedis_strings.gd
@@ -1,0 +1,29 @@
+extends GutTest
+
+const GEDIS := preload("res://addons/gedis/gedis.gd")
+
+func before_each():
+	# Fresh instance per test
+	self.g = GEDIS.new()
+
+func test_set_get_and_default():
+	g.set("a", 1)
+	assert_eq(g.get("a"), 1, "get should return what was set")
+	assert_eq(g.get("missing", 42), 42, "get should return default when missing")
+
+func test_incr_decr():
+	assert_eq(g.incr("n"), 1)
+	assert_eq(g.incr("n", 2), 3)
+	assert_eq(g.decr("n", 4), -1)
+
+func test_del_exists_and_keys_glob():
+	g.set("user:1", "ok")
+	g.set("user:2", "ok")
+	g.set("foo", 123)
+	assert_true(g.exists("user:1"))
+	assert_true(g.exists("foo"))
+	assert_false(g.exists("nope"))
+	var ks := g.keys("user:?")
+	assert_true(ks.has("user:1") && ks.has("user:2") && ks.size() == 2, "glob should match exactly two user keys")
+	assert_eq(g.del("foo"), 1)
+	assert_false(g.exists("foo"))


### PR DESCRIPTION
This PR introduces an initial automated test suite for Gedis using GUT (Godot Unit Test).

What’s included
- Minimal Godot project file (project.godot) to run tests headlessly
- Unit tests under test/unit/ covering:
  - Strings/Numbers: set/get/default, incr/decr, del/exists, glob matching in keys
  - Hashes: hset/hget/default, hdel, hgetall
  - Lists: lpush/rpush, lpop/rpop, llen
  - Sets: sadd/srem/smembers/sismember
  - Expiry: expire/ttl/eviction, persist, flushall

How to run locally
1) Add GUT to the repo (one-time):
   - Install the GUT addon via the Godot Asset Library, or
   - Clone GUT into addons/gut:

      git clone https://github.com/bitwes/Gut.git addons/gut

2) Run tests headless (Godot 4.5):

      godot --headless -s res://addons/gut/gut_cmdln.gd -gdir=res://test -gexit -ginclude_subdirs

Notes
- I attempted to add a GitHub Actions workflow (.github/workflows/tests.yml) to run GUT on pushes/PRs, but the API returned 404 when writing to that path (possibly due to org settings/policies around Actions). If Actions are enabled for this org, I can add the workflow in a follow-up PR or push it once permissions allow.

Let me know if you want additional coverage (e.g., edge cases around type switching between data structures, large-key performance, or fuzz testing).